### PR TITLE
feat: add methods to get active tray and tray stack from TrayProvider

### DIFF
--- a/src/TrayProvider.tsx
+++ b/src/TrayProvider.tsx
@@ -197,8 +197,9 @@ export const TrayProvider = <T extends TrayRegistry>({
           callbackMap[stackId] = { onBackdropPress: callback };
         }
       },
-      activeTray: () => stackMap[stackId]?.[stackMap[stackId].length - 1]?.tray,
-      getTrayStack: () => stackMap[stackId]?.map((t) => t.tray),
+      getActiveTray: () =>
+        stackMap[stackId]?.[stackMap[stackId].length - 1]?.tray,
+      getTrayStack: () => stackMap[stackId],
     }),
 
     [push, modifyStack, stackMap]

--- a/src/TrayProvider.tsx
+++ b/src/TrayProvider.tsx
@@ -197,9 +197,11 @@ export const TrayProvider = <T extends TrayRegistry>({
           callbackMap[stackId] = { onBackdropPress: callback };
         }
       },
+      activeTray: () => stackMap[stackId]?.[stackMap[stackId].length - 1]?.tray,
+      getTrayStack: () => stackMap[stackId]?.map((t) => t.tray),
     }),
 
-    [push, modifyStack]
+    [push, modifyStack, stackMap]
   );
 
   const activeStacks = useMemo(() => Object.entries(stackMap), [stackMap]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -357,4 +357,18 @@ export interface TrayContextType<T extends Record<string, unknown>> {
    * @param {function} callback - The callback function to be invoked when the backdrop is pressed.
    */
   onBackdropPress: (callback: (event: { stackId: string }) => void) => void;
+
+  /**
+   * @method activeTray
+   * @description Returns the tray key of the currently active (top-most) tray in the stack, or undefined if the stack is empty.
+   * @returns {string | undefined} The tray key of the active tray, or undefined.
+   */
+  activeTray: () => string | undefined;
+
+  /**
+   * @method getTrayStack
+   * @description Returns an array of tray keys representing the current stack, from bottom to top.
+   * @returns {string[] | undefined} An array of tray keys in the stack, or undefined if the stack is empty.
+   */
+  getTrayStack: () => string[] | undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,16 +359,16 @@ export interface TrayContextType<T extends Record<string, unknown>> {
   onBackdropPress: (callback: (event: { stackId: string }) => void) => void;
 
   /**
-   * @method activeTray
+   * @method getActiveTray
    * @description Returns the tray key of the currently active (top-most) tray in the stack, or undefined if the stack is empty.
    * @returns {string | undefined} The tray key of the active tray, or undefined.
    */
-  activeTray: () => string | undefined;
+  getActiveTray: () => string | undefined;
 
   /**
    * @method getTrayStack
-   * @description Returns an array of tray keys representing the current stack, from bottom to top.
-   * @returns {string[] | undefined} An array of tray keys in the stack, or undefined if the stack is empty.
+   * @description Returns an array of trays representing the current stack, from bottom to top.
+   * @returns {StackTray[] | undefined} An array of trays in the stack, or undefined if the stack is empty.
    */
-  getTrayStack: () => string[] | undefined;
+  getTrayStack: () => StackTray[] | undefined;
 }


### PR DESCRIPTION
# Pull Request

## Description

Add methods to get the active tray of or the tray stack
<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Lint and tests pass (`yarn lint && yarn test`)
- [ ] Types are correct (`yarn type-check`)
- [x] Docs updated (if necessary)
- [x] Ready for review

## Related Issues

<!-- List any related issues, e.g. "Closes #123" -->
