### PR TITLE
Fix tray positioning when the keyboard is open

### DIFF
--- a/src/TrayRenderer.tsx
+++ b/src/TrayRenderer.tsx
@@ -130,9 +130,28 @@ export const TrayRenderer: React.FC<TrayRendererProps> = ({
       ? Keyboard.addListener('keyboardWillHide', handleKeyboardHide)
       : Keyboard.addListener('keyboardDidHide', handleKeyboardHide);
 
+    // On iOS the will* events fire only once per keyboard presentation; the
+    // did* events carry identical endCoordinates and act as a backstop when
+    // the will* event was missed (e.g. keyboard presented during mount).
+    const showBackstopSub = isIOS
+      ? Keyboard.addListener('keyboardDidShow', handleKeyboardShow)
+      : null;
+    const hideBackstopSub = isIOS
+      ? Keyboard.addListener('keyboardDidHide', handleKeyboardHide)
+      : null;
+
+    // If the keyboard was already up before this tray mounted, no event is
+    // coming at all — seed from the cached metrics.
+    const openKeyboard = Keyboard.metrics();
+    if (openKeyboard) {
+      handleKeyboardShow({ endCoordinates: openKeyboard } as KeyboardEvent);
+    }
+
     return () => {
       showSub.remove();
       hideSub.remove();
+      showBackstopSub?.remove();
+      hideBackstopSub?.remove();
     };
   }, [
     config.adjustForKeyboard,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -40,19 +40,19 @@ export const calculateKeyboardAdjustments = (
 
   const strategies = {
     noAdjustment: {
-      bottom: isAndroid ? -keyboardHeight : insetsBottom,
+      bottom: insetsBottom,
       maxHeight: maxAllowedHeight,
     },
     adjustOnly: {
-      bottom: isAndroid ? 0 : keyboardHeight,
+      bottom: isAndroid ? keyboardHeight + insetsBottom : keyboardHeight,
       maxHeight: maxAllowedHeight,
     },
     clipOnly: {
-      bottom: isAndroid ? -keyboardHeight : insetsBottom,
+      bottom: insetsBottom,
       maxHeight: maxAllowedHeight,
     },
     adjustAndClip: {
-      bottom: isAndroid ? 0 : keyboardHeight,
+      bottom: isAndroid ? keyboardHeight + insetsBottom : keyboardHeight,
       maxHeight: maxAllowedHeight - keyboardHeight + insetsBottom,
     },
     hide: {


### PR DESCRIPTION
# Pull Request

## Description

Android: The tray assumed the window shrinks when the keyboard opens. On edge-to-edge apps (targetSdk 35+) it doesn't, so the tray ended up behind the keyboard. It now moves up by the keyboard height explicitly.

iOS: The tray only listened for keyboardWillShow, which fires once. If the keyboard was already open when the tray mounted (or opened via autoFocus during mount), the event was missed and the tray stayed stuck under the keyboard. It now also listens for keyboardDidShow as a fallback and checks Keyboard.metrics() on mount.

No API changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Lint and tests pass (`yarn lint && yarn test`)
- [x] Types are correct (`yarn type-check`)
- [x] Docs updated (if necessary)
- [x] Ready for review
